### PR TITLE
feat: 커뮤니티 탭바, 헤더 추가 및 목록 출력

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,8 +28,8 @@ function App() {
           <Route path="/commu" element={<CommunityPage />}/>
           <Route path="/mypage" element={<Mypage />}/>
           <Route path="/:region" element={<MainPageDetail />}/>
-          <Route path="/commu/review/:programIdx" element={<RevieDetailPage />}/>
-          <Route path="/commu/together/:programIdx" element={<TogetherDetailPage />}/>
+          <Route path="/commu/review/:reviewIdx" element={<RevieDetailPage />}/>
+          <Route path="/commu/together/:listenIdx" element={<TogetherDetailPage />}/>
         </Routes>
     </div>
     </RecoilRoot>

--- a/src/components/CenterNews/CenterNews.tsx
+++ b/src/components/CenterNews/CenterNews.tsx
@@ -79,7 +79,7 @@ function CenterNews({ lgData }: LGDataArr) {
               programs.map((el, idx) => (
                 <LearningGroundProgram key={idx}>
                   <LearningGroundText>{el.programTitle}</LearningGroundText>
-                  <LearningGroundText>신청 기간 {el.programPeriod}</LearningGroundText>
+                  <LearningGroundText>신청기간 {el.programPeriod}</LearningGroundText>
                 </LearningGroundProgram>
               ))
             }

--- a/src/components/Commu/CommuBest.styled.ts
+++ b/src/components/Commu/CommuBest.styled.ts
@@ -18,13 +18,12 @@ export const Best = styled.div`
   color: #535353;
 `
 export const Text = styled.div`
-    position: relative;
-    width: 170px;
-     height: 50px;
-     border: 3px solid #767676;
-     margin-top: 9px;
-    margin-left: 18px;
-
+  position: relative;
+  width: 170px;
+  height: 50px;
+  border: 3px solid #767676;
+  margin-top: 9px;
+  margin-left: 18px;
 `
 
 //내가 남긴 후기 글 박스
@@ -65,18 +64,36 @@ export const Text1 = styled.div`
 //   color: #535353;
 
 //`
-export const Stylebutton = styled.button`
-    position: relative;
-  width: 920px;
-  height: 46px;
+
+export const CommuPostBtnContainer = styled.div`
+  width: 57.5rem;
+  height: 2.875rem;
+  position: absolute;
+  bottom: 0;
   border: 2px solid #CBCBCB;
   border-radius: 20px;
-  font-size: 18px;
-  font-weight: 600;
-  color: #535353;
+  font-size: 20px;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.61);;
   background: none;
-  .Write{
-    margin-right: 13px;
+`
+
+export const Stylebutton = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 16.5rem;
+  height: 2.875rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  #commu-post-btn__img {
+    width: 1.75rem;
+    height: 1.75rem;
   }
 
+  #commu-post-btn__text {
+  }
 `

--- a/src/components/Commu/CommuBest.tsx
+++ b/src/components/Commu/CommuBest.tsx
@@ -18,15 +18,15 @@ function CommuBest() {
 
     const [data, setData] = useState<IData[]>([]);
 
-    useEffect(() => {
-        axios.get('')
-          .then(response => {
-            setData(response.data);
-          })
-          .catch(error => {
-            console.error(error);
-          });
-      }, []);
+    // useEffect(() => {
+    //     axios.get('')
+    //       .then(response => {
+    //         setData(response.data);
+    //       })
+    //       .catch(error => {
+    //         console.error(error);
+    //       });
+    //   }, []);
 
   return (
     <div>

--- a/src/components/Commu/CommuHeader/CommuHeader.styled.ts
+++ b/src/components/Commu/CommuHeader/CommuHeader.styled.ts
@@ -1,0 +1,6 @@
+import styled from "styled-components";
+
+export const CommuHeaderContainer = styled.div`
+  width: 57.5rem;
+  height: 18.3125rem;
+`

--- a/src/components/Commu/CommuHeader/CommuHeader.tsx
+++ b/src/components/Commu/CommuHeader/CommuHeader.tsx
@@ -1,0 +1,19 @@
+import { CommuHeaderContainer } from "./CommuHeader.styled";
+import { commuTabKind } from "../../../recoil/community";
+import { useRecoilValue } from "recoil";
+import DeToHeader from "../DeToHeader";
+
+function CommuHeader () {
+  const commuTab = useRecoilValue(commuTabKind);
+
+  return(
+    <CommuHeaderContainer>
+      {
+        (commuTab == 'review' || 'together') &&
+        (<DeToHeader />)
+      }
+    </CommuHeaderContainer>
+  )
+}
+
+export default CommuHeader;

--- a/src/components/Commu/CommuHeader/index.tsx
+++ b/src/components/Commu/CommuHeader/index.tsx
@@ -1,0 +1,3 @@
+import CommuHeader from "./CommuHeader";
+
+export default CommuHeader;

--- a/src/components/Commu/CommuList/CommuList.styled.ts
+++ b/src/components/Commu/CommuList/CommuList.styled.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const CommuListContainer = styled.div`
+  width: 57.5rem;
+  height: max-content;
+  position: absolute;
+  top: 51.5rem;
+  left: 24.5rem;
+`

--- a/src/components/Commu/CommuList/CommuList.styled.ts
+++ b/src/components/Commu/CommuList/CommuList.styled.ts
@@ -7,3 +7,10 @@ export const CommuListContainer = styled.div`
   top: 51.5rem;
   left: 24.5rem;
 `
+
+export const CommuCardContainer = styled.div`
+  width: 57.5rem;
+  height: max-content;
+  position: absolute;
+  top: 4.25rem;
+`

--- a/src/components/Commu/CommuList/CommuList.tsx
+++ b/src/components/Commu/CommuList/CommuList.tsx
@@ -78,6 +78,7 @@ function CommuList () {
             currentNum: res[key].currentNum,
             tags: res[key].tags,
             programName: res[key].programName,
+            listenIdx: res[key].listenIdx,
             detailOrCommu: 'community'
           }
           tempArr.push(tempEl);

--- a/src/components/Commu/CommuList/CommuList.tsx
+++ b/src/components/Commu/CommuList/CommuList.tsx
@@ -1,0 +1,12 @@
+import { CommuListContainer } from "./CommuList.styled";
+import CommuRegion from "../CommuRegion";
+
+function CommuList () {
+  return(
+    <CommuListContainer>
+      <CommuRegion />
+    </CommuListContainer>
+  )
+}
+
+export default CommuList;

--- a/src/components/Commu/CommuList/CommuList.tsx
+++ b/src/components/Commu/CommuList/CommuList.tsx
@@ -1,10 +1,143 @@
-import { CommuListContainer } from "./CommuList.styled";
+import { 
+  CommuListContainer, 
+  CommuCardContainer 
+} from "./CommuList.styled";
 import CommuRegion from "../CommuRegion";
+import { commuRegions, commuTabKind, selectedRegion } from "../../../recoil/community";
+import { useRecoilValue } from "recoil";
+import { ReviewData, CommuReviewData } from "../../../types/review";
+import { CommuTogetherData, TogetherData } from "../../../types/together";
+import { useState, useEffect } from "react";
+import axios from "axios";
+import Review from "../../Review";
+import Together from "../../Together";
 
 function CommuList () {
+  const regions = useRecoilValue(commuRegions);
+  const commuTab = useRecoilValue(commuTabKind);
+  const selected = useRecoilValue(selectedRegion);
+  const [commuReviews, setCommuReviews] = useState<CommuReviewData[]>([]);
+  const [commuTogethers, setCommuTogethers] = useState<CommuTogetherData[]>([]);
+
+  useEffect(() => {
+    setCommuReviews([]);
+    setCommuTogethers([]);
+    if(commuTab == 'review') {
+      getReviews();
+      return;
+    }
+    if(commuTab == 'together') {
+      getTogethers();
+      return;
+    }
+  }, [regions, commuTab, selected])
+
+  function getReviews () {
+    regions.map((el) => {
+      axios.get(`${import.meta.env.VITE_APP_HOST}/review/page/${el}`)
+      .then((response) => {
+        const res = response.data.data.reviews;
+        const tempArr: ReviewData[] = [];
+        for(let key in res) {
+          const tempEl: ReviewData = {
+            userNick: res[key].nickName,
+            time: '18시간 전',
+            title: res[key].title,
+            lecture: res[key].programName,
+            content: res[key].content,
+            region: res[key].tags[0],
+            reviewIdx: res[key].reviewIdx,
+            detailPlace: res[key].tags[1],
+            detailOrCommu: 'community'
+          }
+          tempArr.push(tempEl);
+        }
+        setCommuReviews(commuReviews => [...commuReviews, {
+          region: el,
+          reviews: tempArr
+        }]);
+      })
+      .catch((err) => console.log(err));
+    })
+  }
+
+  function getTogethers () {
+    regions.map((el) => {
+      axios.get(`${import.meta.env.VITE_APP_HOST}/listen/page/${el}`)
+      .then((response) => {
+        const res = response.data.data.listenTogethers;
+        const tempArr: TogetherData[] = [];
+        for(let key in res) {
+          const tempEl: TogetherData = {
+            nickname: res[key].nickName,
+            time: '18시간 전',
+            recruiting: res[key].recruiting,
+            title: res[key].title,
+            favFields: res[key].favFields,
+            goalNum: res[key].goalNum,
+            currentNum: res[key].currentNum,
+            tags: res[key].tags,
+            programName: res[key].programName,
+            detailOrCommu: 'community'
+          }
+          tempArr.push(tempEl);
+        }
+        setCommuTogethers(commuTogethers => [...commuTogethers, {
+          region: el,
+          togethers: tempArr
+        }]);
+      })
+      .catch((err) => console.log(err));
+    })  
+  }
+
   return(
     <CommuListContainer>
       <CommuRegion />
+      <CommuCardContainer>
+        {
+          (commuTab == 'review') && (commuReviews) &&
+          (
+            (selected == "전체보기") ? (
+              commuReviews.map((el) =>
+                (
+                  el.reviews.map((el, idx) => (
+                    <Review props={el} key={idx} ></Review>
+                  ))
+              ))
+            ) : (
+              commuReviews.map((el) => (
+                (el.region == selected) && (
+                  el.reviews.map((el, idx) => (
+                    <Review props={el} key={idx} ></Review>
+                  ))
+                )
+              ))
+            )
+          )
+        }
+                {
+          (commuTab == 'together') && (commuTogethers) &&
+          (
+            (selected == "전체보기") ? (
+              commuTogethers.map((el) =>
+                (
+                  el.togethers.map((el, idx) => (
+                    <Together prop={el} key={idx} ></Together>
+                  ))
+              ))
+            ) : (
+              commuTogethers.map((el) => (
+                (el.region == selected) && (
+                  el.togethers.map((el, idx) => (
+                    <Together prop={el} key={idx} ></Together>
+                  ))
+                )
+              ))
+            )
+          )
+        }
+      </CommuCardContainer>
     </CommuListContainer>
   )
 }

--- a/src/components/Commu/CommuList/index.tsx
+++ b/src/components/Commu/CommuList/index.tsx
@@ -1,0 +1,3 @@
+import CommuList from "./CommuList";
+
+export default CommuList;

--- a/src/components/Commu/CommuMyPost.tsx
+++ b/src/components/Commu/CommuMyPost.tsx
@@ -14,19 +14,19 @@ interface IData {
     day: string;
   }
 
-function CommuBest() {
+function CommuMyPost() {
 
     const [data, setData] = useState<IData[]>([]);
 
-    useEffect(() => {
-        axios.get('')
-          .then(response => {
-            setData(response.data);
-          })
-          .catch(error => {
-            console.error(error);
-          });
-      }, []);
+    // useEffect(() => {
+    //     axios.get('')
+    //       .then(response => {
+    //         setData(response.data);
+    //       })
+    //       .catch(error => {
+    //         console.error(error);
+    //       });
+    //   }, []);
 
   return (
     <div>
@@ -43,4 +43,4 @@ function CommuBest() {
   )
 }
 
-export default CommuBest
+export default CommuMyPost

--- a/src/components/Commu/CommuPostBtn.tsx
+++ b/src/components/Commu/CommuPostBtn.tsx
@@ -1,25 +1,25 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom';
 import {
-    Stylebutton
-
+  CommuPostBtnContainer,
+  Stylebutton
 } from './CommuBest.styled'
 import Write from '../../assets/Write.png'
 
 function CommuPostBtn() {
-    const navigate = useNavigate();
+  const navigate = useNavigate();
 
-    const goMypage =()=>{ //일단은 마이페이지로 해놓았음
-        navigate("/mypage");
-      }
+  const goMypage =()=>{ //일단은 마이페이지로 해놓았음
+      navigate("/mypage");
+  }
+  
   return (
-    <div>
-              <Stylebutton onClick={goMypage}>
-              <img className="Write" alt="1" src={Write} />
-                나의 배움에 대해 작성해보세요!
-              </Stylebutton>
-       
-    </div>
+    <CommuPostBtnContainer>
+      <Stylebutton onClick={goMypage}>
+        <img id='commu-post-btn__img' alt="write-img" src={Write} />
+        <div id='commu-post-btn__text'>함께 배울 친구를 찾아보세요!</div>
+      </Stylebutton>
+    </CommuPostBtnContainer>
   )
 }
 

--- a/src/components/Commu/CommuRegion/CommuRegion.styled.ts
+++ b/src/components/Commu/CommuRegion/CommuRegion.styled.ts
@@ -1,0 +1,66 @@
+import styled from "styled-components";
+
+export const CommuRegionContainer = styled.div`
+  width: 57.5rem;
+  height: 4.25rem;
+  display: flex;
+`;
+
+export const CommuRegionBtnBox = styled.div`
+  width: max-content;
+  height: 2.25rem;
+  display: flex;
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+
+  .commu-region__btn {
+    width: max-content;
+    height: 2.25rem;
+    background-color: #dadada;
+    color: #535353;
+    font-size: 20px;
+    font-weight: 500;
+    border-radius: 0.75rem;
+    line-height: 2.25rem;
+    padding: 3px 17px;
+    margin-right: 0.75rem;
+    cursor: pointer;
+    letter-spacing: -0.05em;
+  }
+
+  .active {
+    background-color: #59cacb;
+    color: #fff;
+    font-weight: 700;
+  }
+`;
+
+export const CommuSearchBox = styled.div`
+  width: 18.5rem;
+  height: 2.03125rem;
+  border-bottom: 2px solid #cbcbcb;
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  display: flex;
+  justify-content: space-between;
+
+  #commu-region__search-form {
+    width: 16rem;
+    height: 1.1875rem;
+    border: 0;
+    outline: none;
+    padding: 0;
+    font-size: 16px;
+    font-weight: 600;
+    font-family: Pretendard;
+  }
+
+  #commu-region__search-icon {
+    width: 1.09375rem;
+    height: 1.09375rem;
+  }
+`;

--- a/src/components/Commu/CommuRegion/CommuRegion.styled.ts
+++ b/src/components/Commu/CommuRegion/CommuRegion.styled.ts
@@ -4,6 +4,8 @@ export const CommuRegionContainer = styled.div`
   width: 57.5rem;
   height: 4.25rem;
   display: flex;
+  position: absolute;
+  border-bottom: 2px solid #cbcbcb;
 `;
 
 export const CommuRegionBtnBox = styled.div`

--- a/src/components/Commu/CommuRegion/CommuRegion.tsx
+++ b/src/components/Commu/CommuRegion/CommuRegion.tsx
@@ -6,12 +6,19 @@ import {
 import axios from "axios";
 import { useEffect, useState } from "react";
 import { loginState } from "../../../recoil/user";
-import { useRecoilValue } from "recoil";
+import { commuRegions, selectedRegion } from "../../../recoil/community";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import search_icon from '../../../assets/search_icon.png';
+import { 
+  ReviewData,
+  CommuReviewData
+} from "../../../types/review";
 
 function CommuRegion () {
   const state = useRecoilValue(loginState);
-  const [regions, setRegions] = useState<string[]>([]);
+  const regions = useRecoilValue(commuRegions);
+  const setRegions = useSetRecoilState(commuRegions);
+  const setSelectedRegion = useSetRecoilState(selectedRegion);
 
   useEffect(() => {
     const token = localStorage.getItem('access_token');
@@ -56,6 +63,7 @@ function CommuRegion () {
       el.className = 'commu-region__btn';
     });
     e.currentTarget.className = 'commu-region__btn active';
+    setSelectedRegion(e.currentTarget.innerText);
   }
 
   return(

--- a/src/components/Commu/CommuRegion/CommuRegion.tsx
+++ b/src/components/Commu/CommuRegion/CommuRegion.tsx
@@ -9,10 +9,6 @@ import { loginState } from "../../../recoil/user";
 import { commuRegions, selectedRegion } from "../../../recoil/community";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import search_icon from '../../../assets/search_icon.png';
-import { 
-  ReviewData,
-  CommuReviewData
-} from "../../../types/review";
 
 function CommuRegion () {
   const state = useRecoilValue(loginState);

--- a/src/components/Commu/CommuRegion/CommuRegion.tsx
+++ b/src/components/Commu/CommuRegion/CommuRegion.tsx
@@ -1,0 +1,79 @@
+import { 
+  CommuRegionContainer,
+  CommuRegionBtnBox,
+  CommuSearchBox
+} from "./CommuRegion.styled";
+import axios from "axios";
+import { useEffect, useState } from "react";
+import { loginState } from "../../../recoil/user";
+import { useRecoilValue } from "recoil";
+import search_icon from '../../../assets/search_icon.png';
+
+function CommuRegion () {
+  const state = useRecoilValue(loginState);
+  const [regions, setRegions] = useState<string[]>([]);
+
+  useEffect(() => {
+    const token = localStorage.getItem('access_token');
+
+    if(token) {
+      getRegionsLogIn(token);
+      return;
+    }
+
+    if(!token) {
+      getRegions();
+      return;
+    }
+
+  }, [state])
+
+  // 로그인 X일 때
+  function getRegions() {
+    axios.get(`${import.meta.env.VITE_APP_HOST}/user/regions`)
+    .then((response) => {
+      setRegions(response.data.data.regions);
+    })
+    .catch((err) => console.log(err))
+  }
+
+  // 로그인 O일 때
+  function getRegionsLogIn(token: string) {
+    axios.get(`${import.meta.env.VITE_APP_HOST}/user/regions`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    .then((response) => {
+      setRegions(response.data.data.regions);
+    })
+    .catch((err) => console.log(err))
+  }
+
+  function clickRegion (e: React.MouseEvent<HTMLDivElement>) {
+    const regionArr = document.querySelectorAll('.commu-region__btn');
+    regionArr.forEach((el) => {
+      el.className = 'commu-region__btn';
+    });
+    e.currentTarget.className = 'commu-region__btn active';
+  }
+
+  return(
+    <CommuRegionContainer>
+      <CommuRegionBtnBox>
+      <div className="commu-region__btn active" onClick={e => clickRegion(e)} >전체보기</div>
+      {
+        regions.map((el, idx) => (
+          <div className="commu-region__btn" key={idx} onClick={e => clickRegion(e)}>{el}</div>
+        ))
+      }
+      </CommuRegionBtnBox>
+      <CommuSearchBox>
+        <input id="commu-region__search-form" type="text" placeholder="제목 또는 내용 입력" />
+        <img id="commu-region__search-icon" src={search_icon} alt="search-icon" />
+      </CommuSearchBox>
+    </CommuRegionContainer>
+  )
+}
+
+export default CommuRegion;

--- a/src/components/Commu/CommuRegion/index.tsx
+++ b/src/components/Commu/CommuRegion/index.tsx
@@ -1,0 +1,3 @@
+import CommuRegion from "./CommuRegion";
+
+export default CommuRegion;

--- a/src/components/Commu/CommuTab/CommuTab.styled.ts
+++ b/src/components/Commu/CommuTab/CommuTab.styled.ts
@@ -1,0 +1,32 @@
+import styled from "styled-components";
+
+export const CommuTabContainer = styled.div`
+  width: 13.25rem;
+  height: 11.75rem;
+  position: absolute;
+  top: 27.1875rem;
+  left: 8.875rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  .active {
+    background-color: rgba(89, 199, 200, 0.4);
+    color: #000;
+  }
+`;
+
+export const CommuTabBtn = styled.div`
+  width: 13.25rem;
+  height: 3.75rem;
+  border: 0;
+  border-radius: 0.6rem;
+  font-size: 20px;
+  font-weight: 600;
+  color: #535353;
+  background-color: #fff;
+  letter-spacing: -0.05em;
+  line-height: 3.75rem;
+  padding-left: 1rem;
+  cursor: pointer;
+`;

--- a/src/components/Commu/CommuTab/CommuTab.tsx
+++ b/src/components/Commu/CommuTab/CommuTab.tsx
@@ -1,0 +1,54 @@
+import { 
+  CommuTabContainer,
+  CommuTabBtn
+} from "./CommuTab.styled";
+import { commuTabKind } from "../../../recoil/community";
+import { useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+
+function CommuTab(props: any) {
+  const setCommuTab = useSetRecoilState(commuTabKind);
+  useEffect(() => {
+    setCommuTab('review');
+  },[])
+
+  function btnClick(e: React.MouseEvent<HTMLDivElement>) {
+    const tabArr = document.querySelectorAll('.community-tab__btn');
+    tabArr.forEach((el) => {
+      el.classList.remove('active');
+    })
+    const target = e.currentTarget as HTMLDivElement;
+    target.classList.add('active');
+
+    if(e.currentTarget.id == 'community-tab__together') {
+      setCommuTab('together');
+      return;
+    }
+
+    if(e.currentTarget.id == 'community-tab__review') {
+      setCommuTab('review');
+      return;
+    }
+
+    if(e.currentTarget.id == 'community-tab__free-board') {
+      setCommuTab('freeBoard');
+      return;
+    }
+  }
+
+  return(
+    <CommuTabContainer>
+      <CommuTabBtn id="community-tab__review"
+        className="community-tab__btn active" 
+        onClick={e => btnClick(e)}>수강 후기</CommuTabBtn>
+      <CommuTabBtn id="community-tab__together"
+        className="community-tab__btn" 
+        onClick={e => btnClick(e)}>같이 듣기</CommuTabBtn>
+      <CommuTabBtn id="community-tab__free-board"
+        className="community-tab__btn" 
+        onClick={e => btnClick(e)}>자유게시판</CommuTabBtn>
+    </CommuTabContainer>
+  )
+}
+
+export default CommuTab;

--- a/src/components/Commu/CommuTab/index.tsx
+++ b/src/components/Commu/CommuTab/index.tsx
@@ -1,0 +1,3 @@
+import CommuTab from "./CommuTab";
+
+export default CommuTab

--- a/src/components/Commu/DeToHeader/DeToHeader.styled.ts
+++ b/src/components/Commu/DeToHeader/DeToHeader.styled.ts
@@ -1,0 +1,39 @@
+import styled from "styled-components";
+
+export const DeToHeaderContainer = styled.div`
+  width: 57.5rem;
+  height: 18.3125rem;
+  display: flex;
+  justify-content: space-between;
+  position: absolute;
+  top: 27.3125rem;
+  left: 24.625rem;
+
+  .deto-header__title {
+    font-size: 21px;
+    font-weight: 700;
+  }
+`;
+
+export const DeToMyPost = styled.div`
+  width: 13.375rem;
+  height: 11.625rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+export const DeToBest = styled.div`
+  width: 42rem;
+  height: 11.3rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+export const CommuBestContainer = styled.div`
+  width: 42rem;
+  height: 8.25rem;
+  display: flex;
+  justify-content: space-between;
+`

--- a/src/components/Commu/DeToHeader/DeToHeader.tsx
+++ b/src/components/Commu/DeToHeader/DeToHeader.tsx
@@ -1,0 +1,35 @@
+import { 
+  DeToHeaderContainer,
+  DeToMyPost,
+  DeToBest,
+  CommuBestContainer
+} from "./DeToHeader.styled";
+import { commuTabKind } from "../../../recoil/community";
+import { useRecoilValue } from "recoil";
+import CommuBest from "../CommuBest";
+import CommuMyPost from "../CommuMyPost";
+import CommuPostBtn from "../CommuPostBtn";
+
+function DeToHeader () {
+  const commuTab = useRecoilValue(commuTabKind);
+
+  return(
+    <DeToHeaderContainer>
+      <DeToMyPost>
+        <div className="deto-header__title">내가 남긴 후기</div>
+        <CommuMyPost></CommuMyPost>
+      </DeToMyPost>
+      <DeToBest>
+        <div className="deto-header__title">내 관심지역 인기글</div>
+        <CommuBestContainer>
+          <CommuBest></CommuBest>
+          <CommuBest></CommuBest>
+          <CommuBest></CommuBest>
+        </CommuBestContainer>
+      </DeToBest>
+      <CommuPostBtn></CommuPostBtn>
+    </DeToHeaderContainer>
+  )
+}
+
+export default DeToHeader;

--- a/src/components/Commu/DeToHeader/index.tsx
+++ b/src/components/Commu/DeToHeader/index.tsx
@@ -1,0 +1,3 @@
+import DeToHeader from "./DeToHeader";
+
+export default DeToHeader;

--- a/src/components/DetailContent/DetailContent.tsx
+++ b/src/components/DetailContent/DetailContent.tsx
@@ -4,7 +4,6 @@ import Review from "../Review";
 import { DetailContentContainer } from "./DetailContent.styled";
 import { detailTabKind } from "../../recoil/detail";
 import { useRecoilValue } from "recoil";
-import temp_program from "../../assets/temp_program.jpg";
 import { detailOrCommu, ReviewData } from "../../types/review";
 import axios from "axios";
 import { useEffect, useState } from "react";
@@ -13,30 +12,8 @@ import { TogetherData } from "../../types/together";
 
 function DetailContent() {
   const detailTab = useRecoilValue(detailTabKind);
-  const detail: detailOrCommu = 'detail';
   const [togetherArr, setTogetherArr] = useState<TogetherData[]>([]);
   const [reviewArr, setReviewArr] = useState<ReviewData[]>([]);
-
-  const reviewData = {
-    userNick: '다채 고수',
-    time: '18시간 전',
-    title: '[1주차 후기] 강의 들은 후기입니다 (제목자리)',
-    lecture: '신박한 정리를 위한 미니멀리즘(강의명)',
-    content: `가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다
-    가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다
-    가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다
-    가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다
-    가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다
-    가 나 다 가 나 다 가 나 다 가 나`,
-    region: '은평구',
-    detailPlace: '봉산아래공동체주택동네배움터',
-    reviewImg: [
-      temp_program,
-      temp_program,
-      temp_program
-    ],
-    detailOrCommu: detail
-  }
 
   const { region } = useParams();
 

--- a/src/components/DetailContent/DetailContent.tsx
+++ b/src/components/DetailContent/DetailContent.tsx
@@ -3,14 +3,18 @@ import Together from "../Together";
 import Review from "../Review";
 import { DetailContentContainer } from "./DetailContent.styled";
 import { detailTabKind } from "../../recoil/detail";
-import { useRecoilValue } from "recoil";
-import { detailOrCommu, ReviewData } from "../../types/review";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { ReviewData } from "../../types/review";
 import axios from "axios";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { TogetherData } from "../../types/together";
 
 function DetailContent() {
+  const setTab = useSetRecoilState(detailTabKind);
+  useEffect(() => {
+    setTab('together');
+  }, [])
   const detailTab = useRecoilValue(detailTabKind);
   const [togetherArr, setTogetherArr] = useState<TogetherData[]>([]);
   const [reviewArr, setReviewArr] = useState<ReviewData[]>([]);

--- a/src/components/DetailContent/DetailContent.tsx
+++ b/src/components/DetailContent/DetailContent.tsx
@@ -57,6 +57,7 @@ function DetailContent() {
             lecture: response[key].programName,
             content: response[key].content,
             region: response[key].tags[0],
+            reviewIdx: response[key].reviewIdx,
             detailPlace: response[key].tags[1],
             detailOrCommu: 'detail'
           }

--- a/src/components/MainDetailProgram/MainDetailProgram.tsx
+++ b/src/components/MainDetailProgram/MainDetailProgram.tsx
@@ -27,7 +27,6 @@ const MainDetailProgram = ({ region }: Props)=> {
                 `${import.meta.env.VITE_APP_HOST}/program/page/${region}`
             );
             setData(response.data.data.programs);
-            console.log(response.data.data);
         } catch (e) {
             console.log(e);
         }
@@ -35,8 +34,6 @@ const MainDetailProgram = ({ region }: Props)=> {
     }
     fetchData();
 },  [region]);
-console.log(data);
-
 
   return (
     <div>

--- a/src/components/Review/Review.tsx
+++ b/src/components/Review/Review.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { ReviewProps } from "../../types/review";
 import { 
   ReviewContainer,
@@ -12,10 +13,11 @@ import {
 } from "./Review.styled";
 
 function Review({ props }: ReviewProps) {
+  const navigate = useNavigate();
   const [count, setCount] = useState(0);
   const [viewContent, setViewContent] = useState('');
   const [overLength, setOverLength] = useState(false);
-  const { userImg, userNick, time, title, lecture, content, region, detailPlace, reviewImg, detailOrCommu } = props;
+  const { userImg, userNick, time, title, lecture, content, region, detailPlace, reviewImg, reviewIdx, detailOrCommu } = props;
 
   function countImg() {
     if(reviewImg && (reviewImg?.length > 0)) {
@@ -40,9 +42,14 @@ function Review({ props }: ReviewProps) {
     countImg();
     checkContentLength();
   }, []);
+
+  function clickReview () {
+    navigate(`/commu/review/${reviewIdx}`);
+    return;
+  }
  
   return (
-    <ReviewContainer detailOrCommu={detailOrCommu} >
+    <ReviewContainer detailOrCommu={detailOrCommu} onClick={clickReview} >
       <ReviewProfile>
         <div id="review__profile-photo"></div>
         <div>

--- a/src/components/Together/Together.styled.ts
+++ b/src/components/Together/Together.styled.ts
@@ -1,7 +1,8 @@
 import styled from "styled-components";
+import { detailOrCommu } from "../../types/review";
 
-export const TogetherContainer = styled.div`
-  width: 72.25rem;
+export const TogetherContainer = styled.div<{ detailOrCommu: detailOrCommu }>`
+  width: ${props => props.detailOrCommu == 'detail' ? '72.25rem' : '57.5rem'};
   height: 21.4375rem;
   border-bottom: 2px solid #cbcbcb;
   margin: 0 auto;
@@ -50,8 +51,9 @@ export const TogetherInfo = styled.div`
   line-height: 1.875rem;
 `;
 
-export const TogetherFooter = styled.div`
-  width: 69.25rem;
+export const TogetherFooter = styled.div<{ detailOrCommu: detailOrCommu }>`
+  // width: 69.25rem;
+  width: ${props => props.detailOrCommu == 'detail' ? '69.25rem' : '57.5rem'};
   height: 2.625rem;
   position: absolute;
   top: 16.125rem;

--- a/src/components/Together/Together.tsx
+++ b/src/components/Together/Together.tsx
@@ -12,8 +12,10 @@ import { useEffect, useState } from "react";
 import recruiting_img from '../../assets/recruiting.png';
 import recruited_img from '../../assets/recruited.png';
 import { TogetherProp } from "../../types/together";
+import { useNavigate } from "react-router-dom";
 
 function Together ({ prop }: TogetherProp) {
+  const navigate = useNavigate();
   const [favStr, setFavStr] = useState<string>('');
 
   const favToStr = (favFields: Array<string>):void => {
@@ -38,6 +40,11 @@ function Together ({ prop }: TogetherProp) {
     favToStr(prop.favFields);
   }, [])
 
+  function clickTogether() {
+    navigate(`/commu/together/${prop.listenIdx}`);
+    return;
+  }
+
   return(
     <TogetherContainer detailOrCommu={prop.detailOrCommu} >
       <ReviewProfile topProp={true}>
@@ -47,7 +54,7 @@ function Together ({ prop }: TogetherProp) {
           <div id="review__profile-time">{prop.time}</div>
         </div>
       </ReviewProfile>
-      <TogetherTitle recruiting={prop.recruiting}>
+      <TogetherTitle recruiting={prop.recruiting} onClick={clickTogether} >
         <div id="together__recruiting">{prop.recruiting ? "모집중" : "모집완료"}</div>
         <div id="together__title">{prop.title}</div>
       </TogetherTitle>

--- a/src/components/Together/Together.tsx
+++ b/src/components/Together/Together.tsx
@@ -16,24 +16,6 @@ import { TogetherProp } from "../../types/together";
 function Together ({ prop }: TogetherProp) {
   const [favStr, setFavStr] = useState<string>('');
 
-  // 추후 api 호출 반영을 위한 동적 데이터
-  // const props = {
-  //   nickname: '다채 고수',
-  //   time: '18시간 전',
-  //   recruiting: true,
-  //   title: '성복구 레진아트 강좌 같이 들을 분 계실까요?^^',
-  //   favFields: [
-  //     "문화여가", "자기계발"
-  //   ],
-  //   goalNum: 5,
-  //   currentNum: 2,
-  //   tags: [
-  //     "은평구",
-  //     "봉산아래공동체주택동네배움터"
-  //   ],
-  //   programName: "초보를 위한 레진아트 수업"
-  // }
-
   const favToStr = (favFields: Array<string>):void => {
     let tempStr = '';
     if(favFields.length <= 0) return;
@@ -57,7 +39,7 @@ function Together ({ prop }: TogetherProp) {
   }, [])
 
   return(
-    <TogetherContainer>
+    <TogetherContainer detailOrCommu={prop.detailOrCommu} >
       <ReviewProfile topProp={true}>
         <div id="review__profile-photo"></div>
         <div>
@@ -73,7 +55,7 @@ function Together ({ prop }: TogetherProp) {
         <div id="together__fav-fields">지원자 활동 분야: {favStr}</div>
         <div id="together__goal-num">희망 인원: {prop.goalNum}명</div>
       </TogetherInfo>
-      <TogetherFooter>
+      <TogetherFooter detailOrCommu={prop.detailOrCommu} >
         <ReviewPlace topProp={true} >
             <div id="review__place-region">&#35;{prop.tags[0]}</div>
             <div id="review__place-detail">&#35;{prop.tags[1]}</div>

--- a/src/components/TogetherDetail/TogetherDetail.tsx
+++ b/src/components/TogetherDetail/TogetherDetail.tsx
@@ -13,25 +13,7 @@ import{
 
 } from './TogetherDetail.styled'
 
-const data ={
-    "title": "함께하자",
-    "programName": "강좌명: 초보를 위한 레진아트 수업",
-    "createdAt": "2023-05-01-13-09",
-    "content": "즐겁게하자",
-    "profile": "test.com",
-    "nickName": "test2",
-    "grade": 1,
-    "favField": [
-      "미술",
-      "창작"
-    ],
-    "currentNum": 0,
-    "goalNum": 5,
-    "hit": 11,
-    "participantsInfos": []
-
-  }
-  interface Program {
+interface Program {
     
     profile:string;
     nickName:string;
@@ -43,7 +25,8 @@ const data ={
     goalNum:number;
     programName:string;
     
-  }
+}
+
 function TogetherDetail({ listenIdx }: { listenIdx: number }) {
     const [isMouseOver, setIsMouseOver] = useState(false);
     const [data, setData] = useState<Program>();

--- a/src/pages/Commu/CommunityPage.styled.ts
+++ b/src/pages/Commu/CommunityPage.styled.ts
@@ -38,6 +38,4 @@ export const MainBanner = styled.div`
   width: 100%;
   height: 240px;
   background-color: #91C8CA;
-  border: 1px solid red;
-
 `

--- a/src/pages/Commu/CommunityPage.tsx
+++ b/src/pages/Commu/CommunityPage.tsx
@@ -8,34 +8,13 @@ import Header from '../../components/Header/Header';
 import CommuBest from '../../components/Commu/CommuBest'
 import CommuMyPost from '../../components/Commu/CommuMyPost'
 import CommuPostBtn from '../../components/Commu/CommuPostBtn';
+import CommuTab from '../../components/Commu/CommuTab';
 import temp_program from "../../assets/temp_program.jpg";
 import { Category } from '../../types/tabCategory';
 import { detailOrCommu } from '../../types/review';
 
 function CommunityPage() {
   const commu: detailOrCommu = 'community';
-
-  const reviewData = {
-    userNick: '다채 고수',
-    time: '18시간 전',
-    title: '[1주차 후기] 강의 들은 후기입니다 (제목자리)',
-    lecture: '신박한 정리를 위한 미니멀리즘(강의명)',
-    content: `가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다
-    가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다
-    가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다
-    가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다
-    가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다 가 나 다
-    가 나 다 가 나 다 가 나 다 가 나`,
-    region: '은평구',
-    detailPlace: '봉산아래공동체주택동네배움터',
-    reviewImg: [
-      temp_program,
-      temp_program,
-      temp_program
-    ],
-    detailOrCommu: commu
-  }
-
   const category: Category = 'community';
 
   return (
@@ -44,13 +23,8 @@ function CommunityPage() {
       <Header>
       </Header>
       <TabBar prop={category} />
-      <MainBanner>
-        배너
-      </MainBanner>
-      {/* <CommuBest/>
-      <CommuMyPost/>
-      <CommuPostBtn/> */}
-      <Review props={reviewData} ></Review>
+      <MainBanner />
+      <CommuTab />
       </>
     </div>
   )

--- a/src/pages/Commu/CommunityPage.tsx
+++ b/src/pages/Commu/CommunityPage.tsx
@@ -5,12 +5,9 @@ import {
 } from "./CommunityPage.styled"
 import TabBar from '../../components/TabBar';
 import Header from '../../components/Header/Header';
-import CommuBest from '../../components/Commu/CommuBest'
-import CommuMyPost from '../../components/Commu/CommuMyPost'
-import CommuPostBtn from '../../components/Commu/CommuPostBtn';
 import CommuTab from '../../components/Commu/CommuTab';
 import CommuHeader from '../../components/Commu/CommuHeader';
-import temp_program from "../../assets/temp_program.jpg";
+import CommuList from '../../components/Commu/CommuList';
 import { Category } from '../../types/tabCategory';
 import { detailOrCommu } from '../../types/review';
 
@@ -26,6 +23,7 @@ function CommunityPage() {
       <MainBanner />
       <CommuTab />
       <CommuHeader />
+      <CommuList />
       </>
     </div>
   )

--- a/src/pages/Commu/CommunityPage.tsx
+++ b/src/pages/Commu/CommunityPage.tsx
@@ -9,6 +9,7 @@ import CommuBest from '../../components/Commu/CommuBest'
 import CommuMyPost from '../../components/Commu/CommuMyPost'
 import CommuPostBtn from '../../components/Commu/CommuPostBtn';
 import CommuTab from '../../components/Commu/CommuTab';
+import CommuHeader from '../../components/Commu/CommuHeader';
 import temp_program from "../../assets/temp_program.jpg";
 import { Category } from '../../types/tabCategory';
 import { detailOrCommu } from '../../types/review';
@@ -20,11 +21,11 @@ function CommunityPage() {
   return (
     <div>
       <>
-      <Header>
-      </Header>
+      <Header/>
       <TabBar prop={category} />
       <MainBanner />
       <CommuTab />
+      <CommuHeader />
       </>
     </div>
   )

--- a/src/pages/Main/MainPageDetail.tsx
+++ b/src/pages/Main/MainPageDetail.tsx
@@ -21,15 +21,11 @@ import MainDetailProgram from '../../components/MainDetailProgram/MainDetailProg
 
 const MainPageDetail = () =>{
   const { region } = useParams();
-  console.log(region);
 
   const navigate = useNavigate();
   const goMainDetail =()=>{
       navigate("/mainDetail");
     }
-
-  
-  
 
   return (
     <div>

--- a/src/pages/TogetherDetail/TogetherDetailPage.tsx
+++ b/src/pages/TogetherDetail/TogetherDetailPage.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
+import { useParams } from 'react-router-dom'
 import TogetherDetail from '../../components/TogetherDetail/TogetherDetail'
 
 function TogetherDetailPage() {
+  const { listenIdx } = useParams();
+
   return (
     <div>
       <TogetherDetail listenIdx ={Number(listenIdx)}/>

--- a/src/recoil/community.ts
+++ b/src/recoil/community.ts
@@ -1,0 +1,7 @@
+import { atom } from 'recoil';
+import { CommuTabType } from '../types/communityTab';
+
+export const commuTabKind = atom<CommuTabType>({
+  key: 'commuTabKind',
+  default: 'review',
+});

--- a/src/recoil/community.ts
+++ b/src/recoil/community.ts
@@ -5,3 +5,13 @@ export const commuTabKind = atom<CommuTabType>({
   key: 'commuTabKind',
   default: 'review',
 });
+
+export const commuRegions = atom<string[]>({
+  key: 'commuRegions',
+  default: []
+});
+
+export const selectedRegion = atom<string>({
+  key: 'selectedRegion',
+  default: "전체보기"
+});

--- a/src/types/communityTab.ts
+++ b/src/types/communityTab.ts
@@ -1,0 +1,1 @@
+export type CommuTabType = 'together' | 'review' | 'freeBoard';

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -9,9 +9,15 @@ export interface ReviewData {
   lecture: string;
   content: string;
   region: string;
+  reviewIdx: number;
   detailPlace: string;
   reviewImg?: string[];
   detailOrCommu: detailOrCommu;
+}
+
+export interface CommuReviewData {
+  region: string;
+  reviews: ReviewData[]
 }
 
 export type ReviewProps = {

--- a/src/types/together.ts
+++ b/src/types/together.ts
@@ -1,3 +1,5 @@
+import { detailOrCommu } from "./review";
+
 export interface TogetherData {
   nickname: string;
   time: string;
@@ -8,6 +10,12 @@ export interface TogetherData {
   currentNum: number;
   tags: string[];
   programName: string;
+  detailOrCommu: detailOrCommu
+}
+
+export interface CommuTogetherData {
+  region: string;
+  togethers: TogetherData[];
 }
 
 export interface TogetherProp {

--- a/src/types/together.ts
+++ b/src/types/together.ts
@@ -10,6 +10,7 @@ export interface TogetherData {
   currentNum: number;
   tags: string[];
   programName: string;
+  listenIdx: number;
   detailOrCommu: detailOrCommu
 }
 


### PR DESCRIPTION
### 추가 기능
- 커뮤니티 탭바 구현
- 커뮤니티 헤더 구현
  - 같이듣기/수강후기/(자유게시판)에 따라 헤더 일부 변화됨
- 같이듣기/수강후기 탭에 따라 해당 목록 출력
- 각 게시글 클릭시 연수가 만든 상세 페이지와 연결

### 추후 개선
- 자유게시판 추가
- 상세 페이지 개선 필요
- useEffect() 로 인한 화면 깜박임 개선

### 화면 캡쳐
![image](https://github.com/KUSITMS-27-chilling/Encore-FE/assets/50830078/f96783e3-dc36-4b8b-8d8e-573413b27810)
↑ 수강 후기 헤더

![image](https://github.com/KUSITMS-27-chilling/Encore-FE/assets/50830078/208e030c-14c3-4f9e-8962-aad3cc777131)
↑ 수강 후기 목록
각 지역 버튼에 맞는 데이터 출력됨

![image](https://github.com/KUSITMS-27-chilling/Encore-FE/assets/50830078/02cd40ac-955f-433f-80cd-94f5f9e6aa5d)
↑ 같이 듣기 헤더

![image](https://github.com/KUSITMS-27-chilling/Encore-FE/assets/50830078/ac0e0a6c-8a0e-4c6e-89e4-e542afc9fd4d)
↑ 같이 듣기 목록
각 지역 버튼에 맞는 데이터 출력됨